### PR TITLE
Added Authorization request property if sonar.login and sonar.password are defined

### DIFF
--- a/sonar-runner-api/src/main/java/org/sonar/runner/Bootstrapper.java
+++ b/sonar-runner-api/src/main/java/org/sonar/runner/Bootstrapper.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.codec.binary.Base64;
 
 /**
  * Bootstrapper used to download everything from the server and create the correct classloader required to execute a Sonar analysis in isolation.
@@ -54,6 +55,8 @@ class Bootstrapper {
 
   private File bootDir;
   private String serverUrl;
+  private String sonarUser;
+  private String sonarPassword;
   private String productToken;
   private String serverVersion;
   private SonarCache cache;
@@ -61,7 +64,7 @@ class Bootstrapper {
   /**
    * @param productToken part of User-Agent request-header field - see http://tools.ietf.org/html/rfc1945#section-10.15
    */
-  Bootstrapper(String productToken, String serverUrl, File workDir, SonarCache cache) {
+  Bootstrapper(String productToken, String serverUrl, File workDir, SonarCache cache,String sonarUser,String sonarPassword) {
     this.productToken = productToken;
     this.cache = cache;
     bootDir = new File(workDir, "batch");
@@ -71,6 +74,8 @@ class Bootstrapper {
     } else {
       this.serverUrl = serverUrl;
     }
+    this.sonarUser = sonarUser;
+    this.sonarPassword = sonarPassword;
   }
 
   /**
@@ -184,6 +189,12 @@ class Bootstrapper {
     connection.setInstanceFollowRedirects(true);
     connection.setRequestMethod("GET");
     connection.setRequestProperty("User-Agent", getUserAgent());
+    if (sonarUser != null && sonarPassword != null){
+        String userPassword = sonarUser + ":" + sonarPassword;
+        String encodedUserPass = new Base64().encodeToString(userPassword.getBytes());
+        connection.setRequestProperty("Authorization", "Basic " + encodedUserPass);
+    }
+
     return connection;
   }
 

--- a/sonar-runner-api/src/main/java/org/sonar/runner/Runner.java
+++ b/sonar-runner-api/src/main/java/org/sonar/runner/Runner.java
@@ -185,13 +185,22 @@ public final class Runner {
    * Runs a Sonar analysis.
    */
   public void execute() {
-    Bootstrapper bootstrapper = new Bootstrapper("SonarRunner/" + Version.getVersion(), getSonarServerURL(), getWorkDir(), getCache());
+    Bootstrapper bootstrapper = new Bootstrapper("SonarRunner/" + Version.getVersion(), getSonarServerURL(), getWorkDir(), getCache(),
+            getSonarUser(),getSonarPassword());
     checkSonarVersion(bootstrapper);
     delegateExecution(createClassLoader(bootstrapper));
   }
 
   public String getSonarServerURL() {
     return projectProperties.getProperty("sonar.host.url", globalProperties.getProperty("sonar.host.url", "http://localhost:9000"));
+  }
+
+  public String getSonarUser(){
+    return projectProperties.getProperty("sonar.login", globalProperties.getProperty("sonar.login"));
+  }
+
+  public String getSonarPassword(){
+    return projectProperties.getProperty("sonar.password", globalProperties.getProperty("sonar.password"));
   }
 
   public SonarCache getCache() {

--- a/sonar-runner-api/src/test/java/org/sonar/runner/BootstrapperTest.java
+++ b/sonar-runner-api/src/test/java/org/sonar/runner/BootstrapperTest.java
@@ -44,19 +44,19 @@ public class BootstrapperTest {
 
   @Test
   public void shouldRemoveLastUrlSlash() {
-    Bootstrapper bootstrapper = new Bootstrapper("", "http://test/", new File("target/tmp"), null);
+    Bootstrapper bootstrapper = new Bootstrapper("", "http://test/", new File("target/tmp"), null,null,null);
     assertThat(bootstrapper.getServerUrl()).isEqualTo("http://test");
   }
 
   @Test(expected = Exception.class)
   public void shouldFailIfCanNotConnectServer() {
-    Bootstrapper bootstrapper = new Bootstrapper("", "http://unknown.foo", new File("target/tmp"), null);
+    Bootstrapper bootstrapper = new Bootstrapper("", "http://unknown.foo", new File("target/tmp"), null,null,null);
     bootstrapper.getServerVersion();
   }
 
   @Test
   public void shouldReturnUserAgent() {
-    Bootstrapper bootstrapper = new Bootstrapper("test/0.1", "http://unknown.foo", new File("target/tmp"), null);
+    Bootstrapper bootstrapper = new Bootstrapper("test/0.1", "http://unknown.foo", new File("target/tmp"), null,null,null);
     String userAgent = bootstrapper.getUserAgent();
 
     assertThat(userAgent.length()).isGreaterThan(0);
@@ -66,7 +66,7 @@ public class BootstrapperTest {
 
   @Test
   public void shouldReturnValidVersion() {
-    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), null) {
+    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), null,null,null) {
       @Override
       String remoteContent(String path) throws IOException {
         return "2.6";
@@ -109,7 +109,7 @@ public class BootstrapperTest {
     connections.register("/batch_bootstrap/index", "foo.jar|922afef30ca31573d7131347d01b76c4\nbar.jar|69155f65900fbabbf21e28abb33dd06a");
     connections.register("/batch/foo.jar", "fakecontent1");
     connections.register("/batch/bar.jar", "fakecontent2");
-    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), cache) {
+    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), cache,null,null) {
       @Override
       HttpURLConnection newHttpConnection(URL url) throws IOException {
         return connections.get(url);
@@ -123,7 +123,7 @@ public class BootstrapperTest {
     final MockedConnectionFactory connections2 = new MockedConnectionFactory("http://test");
     connections2.register("/api/server/version", "3.5");
     connections2.register("/batch_bootstrap/index", "foo.jar|922afef30ca31573d7131347d01b76c4\nbar.jar|69155f65900fbabbf21e28abb33dd06a");
-    Bootstrapper bootstrapper2 = new Bootstrapper("", "http://test", new File("target/tmp"), cache) {
+    Bootstrapper bootstrapper2 = new Bootstrapper("", "http://test", new File("target/tmp"), cache,null,null) {
       @Override
       HttpURLConnection newHttpConnection(URL url) throws IOException {
         return connections2.get(url);
@@ -140,7 +140,7 @@ public class BootstrapperTest {
     connections.register("/batch/", "foo.jar,bar.jar");
     connections.register("/batch/foo.jar", "fakecontent1");
     connections.register("/batch/bar.jar", "fakecontent2");
-    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), SonarCache.create(sonarUserHome).build()) {
+    Bootstrapper bootstrapper = new Bootstrapper("", "http://test", new File("target/tmp"), SonarCache.create(sonarUserHome).build(),null,null) {
       @Override
       HttpURLConnection newHttpConnection(URL url) throws IOException {
         return connections.get(url);

--- a/sonar-runner-api/src/test/java/org/sonar/runner/RunnerTest.java
+++ b/sonar-runner-api/src/test/java/org/sonar/runner/RunnerTest.java
@@ -121,6 +121,22 @@ public class RunnerTest {
   }
 
   @Test
+  public void shouldGetSonarUser() {
+    Properties properties = new Properties();
+    properties.setProperty("sonar.login", "sonar");
+    Runner runner = Runner.create(properties);
+    assertThat(runner.getSonarUser()).isEqualTo("sonar");
+  }
+
+  @Test
+  public void shouldGetSonarPassword() {
+    Properties properties = new Properties();
+    properties.setProperty("sonar.password", "sonarpass");
+    Runner runner = Runner.create(properties);
+    assertThat(runner.getSonarPassword()).isEqualTo("sonarpass");
+  }
+
+  @Test
   public void shouldInitDirs() throws Exception {
     Properties props = new Properties();
     File home = tempFolder.newFolder("shouldInitDirs").getCanonicalFile();


### PR DESCRIPTION
Sonar maven plugin adds this request property, so sonar runner should add it too. It allows to contact sonar behind Basic authentication (e.g. kerberos).
