### PR TITLE
Added possibility to stop the forked runner process

### DIFF
--- a/sonar-runner-api/src/main/java/org/sonar/runner/api/CommandExecutor.java
+++ b/sonar-runner-api/src/main/java/org/sonar/runner/api/CommandExecutor.java
@@ -25,7 +25,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.concurrent.*;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Synchronously execute a native command line. It's much more limited than the Apache Commons Exec library.
@@ -45,7 +50,7 @@ class CommandExecutor {
     return INSTANCE;
   }
 
-  int execute(Command command, StreamConsumer stdOut, StreamConsumer stdErr, long timeoutMilliseconds) {
+  int execute(Command command, StreamConsumer stdOut, StreamConsumer stdErr, long timeoutMilliseconds, ProcessActivityController processActivityController) {
     ExecutorService executorService = null;
     Process process = null;
     StreamGobbler outputGobbler = null;
@@ -62,8 +67,12 @@ class CommandExecutor {
       errorGobbler.start();
 
       executorService = Executors.newSingleThreadExecutor();
-      Future<Integer> ft = executeProcess(executorService, process);
-      int exitCode = ft.get(timeoutMilliseconds, TimeUnit.MILLISECONDS);
+      final Future<Integer> futureTask = executeProcess(executorService, process);
+      if (processActivityController != null) {
+        monitorProcess(processActivityController, executorService, process);
+      }
+
+      int exitCode = futureTask.get(timeoutMilliseconds, TimeUnit.MILLISECONDS);
       waitUntilFinish(outputGobbler);
       waitUntilFinish(errorGobbler);
       verifyGobbler(command, outputGobbler, "stdOut");
@@ -88,6 +97,19 @@ class CommandExecutor {
         executorService.shutdown();
       }
     }
+  }
+
+  private void monitorProcess(final ProcessActivityController processActivityController, final ExecutorService executor, final Process process) {
+    new Thread() {
+      @Override
+      public void run() {
+        while (!executor.isTerminated()) {
+          if (processActivityController.shouldStopProcess()) {
+            process.destroy();
+          }
+        }
+      }
+    }.start();
   }
 
   private Future<Integer> executeProcess(ExecutorService executorService, Process process) {

--- a/sonar-runner-api/src/main/java/org/sonar/runner/api/ForkedRunner.java
+++ b/sonar-runner-api/src/main/java/org/sonar/runner/api/ForkedRunner.java
@@ -25,7 +25,6 @@ import org.sonar.runner.impl.BatchLauncherMain;
 import org.sonar.runner.impl.JarExtractor;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -43,6 +42,7 @@ import java.util.Map;
 public class ForkedRunner extends Runner<ForkedRunner> {
 
   private static final int ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
+  private static final int TERMINATED_STATUS = 143;
 
   private final Map<String, String> jvmEnvVariables = new HashMap<String, String>();
   private final List<String> jvmArguments = new ArrayList<String>();
@@ -51,9 +51,16 @@ public class ForkedRunner extends Runner<ForkedRunner> {
   private final JarExtractor jarExtractor;
   private final CommandExecutor commandExecutor;
 
-  ForkedRunner(JarExtractor jarExtractor, CommandExecutor commandExecutor) {
+  private ProcessActivityController activityController;
+
+  ForkedRunner(JarExtractor jarExtractor, CommandExecutor commandExecutor, ProcessActivityController activityController) {
     this.jarExtractor = jarExtractor;
     this.commandExecutor = commandExecutor;
+    this.activityController = activityController;
+  }
+
+  ForkedRunner(JarExtractor jarExtractor, CommandExecutor commandExecutor) {
+    this(jarExtractor, commandExecutor, null);
   }
 
   /**
@@ -61,6 +68,13 @@ public class ForkedRunner extends Runner<ForkedRunner> {
    */
   public static ForkedRunner create() {
     return new ForkedRunner(new JarExtractor(), CommandExecutor.create());
+  }
+
+  /**
+   * Create new instance. Never return null.
+   */
+  public static ForkedRunner create(ProcessActivityController processActivityController) {
+    return new ForkedRunner(new JarExtractor(), CommandExecutor.create(), processActivityController);
   }
 
   /**
@@ -140,11 +154,11 @@ public class ForkedRunner extends Runner<ForkedRunner> {
       javaExecutable = new Os().thisJavaExe().getAbsolutePath();
     }
     Command command = Command.builder()
-        .setExecutable(javaExecutable)
-        .addEnvVariables(jvmEnvVariables)
-        .addArguments(jvmArguments)
-        .addArguments("-cp", jarFile.getAbsolutePath(), BatchLauncherMain.class.getName(), propertiesFile.getAbsolutePath())
-        .build();
+      .setExecutable(javaExecutable)
+      .addEnvVariables(jvmEnvVariables)
+      .addArguments(jvmArguments)
+      .addArguments("-cp", jarFile.getAbsolutePath(), BatchLauncherMain.class.getName(), propertiesFile.getAbsolutePath())
+      .build();
     return new ForkCommand(command, jarFile, propertiesFile);
   }
 
@@ -176,8 +190,11 @@ public class ForkedRunner extends Runner<ForkedRunner> {
     if (stdErr == null) {
       stdErr = new PrintStreamConsumer(System.err);
     }
-    int status = commandExecutor.execute(forkCommand.command, stdOut, stdErr, ONE_DAY_IN_MILLISECONDS);
-    if (status != 0) {
+    int status = commandExecutor.execute(forkCommand.command, stdOut, stdErr, ONE_DAY_IN_MILLISECONDS, activityController);
+
+    if (status == TERMINATED_STATUS) {
+       stdOut.consumeLine(String.format("Sonar runner terminated with exit code %d", status));
+    } else if (status != 0) {
       throw new IllegalStateException("Error status [command: " + forkCommand.command + "]: " + status);
     }
   }

--- a/sonar-runner-api/src/main/java/org/sonar/runner/api/ProcessActivityController.java
+++ b/sonar-runner-api/src/main/java/org/sonar/runner/api/ProcessActivityController.java
@@ -1,0 +1,26 @@
+/*
+ * Sonar Runner - API
+ * Copyright (C) 2011 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.runner.api;
+
+
+public interface ProcessActivityController {
+
+    boolean shouldStopProcess();
+}

--- a/sonar-runner-api/src/test/java/org/sonar/runner/api/CommandExecutorTest.java
+++ b/sonar-runner-api/src/test/java/org/sonar/runner/api/CommandExecutorTest.java
@@ -31,9 +31,16 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class CommandExecutorTest {
+
+  public static final ProcessActivityController ACTIVITY_CONTROLLER = mock(ProcessActivityController.class);
+
+  public static final int PROCESS_TERMINATED_CODE = 143;
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -68,7 +75,7 @@ public class CommandExecutorTest {
       }
     };
     Command command = Command.builder().setExecutable(getScript("output")).setDirectory(workDir).build();
-    int exitCode = CommandExecutor.create().execute(command, stdOutConsumer, stdErrConsumer, 1000L);
+    int exitCode = CommandExecutor.create().execute(command, stdOutConsumer, stdErrConsumer, 1000L, ACTIVITY_CONTROLLER);
     assertThat(exitCode).isEqualTo(0);
 
     String stdOut = stdOutBuilder.toString();
@@ -84,7 +91,7 @@ public class CommandExecutorTest {
     Command command = Command.builder().setExecutable(getScript("output")).setDirectory(workDir).build();
     thrown.expect(CommandException.class);
     thrown.expectMessage("Error inside stdOut stream");
-    CommandExecutor.create().execute(command, BAD_CONSUMER, NOP_CONSUMER, 1000L);
+    CommandExecutor.create().execute(command, BAD_CONSUMER, NOP_CONSUMER, 1000L, ACTIVITY_CONTROLLER);
   }
 
   @Test
@@ -92,7 +99,7 @@ public class CommandExecutorTest {
     Command command = Command.builder().setExecutable(getScript("output")).setDirectory(workDir).build();
     thrown.expect(CommandException.class);
     thrown.expectMessage("Error inside stdErr stream");
-    CommandExecutor.create().execute(command, NOP_CONSUMER, BAD_CONSUMER, 1000L);
+    CommandExecutor.create().execute(command, NOP_CONSUMER, BAD_CONSUMER, 1000L, ACTIVITY_CONTROLLER);
   }
 
   private static final StreamConsumer NOP_CONSUMER = new StreamConsumer() {
@@ -115,7 +122,7 @@ public class CommandExecutorTest {
         .addArguments("1")
         .setEnvVariable("ENVVAR", "2")
         .build();
-    int exitCode = CommandExecutor.create().execute(command, stdout, stderr, 1000L);
+    int exitCode = CommandExecutor.create().execute(command, stdout, stderr, 1000L, ACTIVITY_CONTROLLER);
     assertThat(exitCode).isEqualTo(0);
     File logFile = new File(workDir, "echo.log");
     assertThat(logFile).exists();
@@ -131,7 +138,7 @@ public class CommandExecutorTest {
     long start = System.currentTimeMillis();
     try {
       Command command = Command.builder().setExecutable(executable).setDirectory(workDir).build();
-      CommandExecutor.create().execute(command, stdout, stderr, 300L);
+      CommandExecutor.create().execute(command, stdout, stderr, 300L, ACTIVITY_CONTROLLER);
       fail();
     } catch (CommandException e) {
       long duration = System.currentTimeMillis() - start;
@@ -142,10 +149,28 @@ public class CommandExecutorTest {
   }
 
   @Test
+  public void test_should_stop_if_requested() throws Exception {
+
+    String executable = getScript("forever");
+    Command command = Command.builder().setExecutable(executable).setDirectory(workDir).build();
+
+    long start = System.currentTimeMillis();
+    int execute = CommandExecutor.create().execute(command, stdout, stderr, 1000L, new ProcessActivityController() {
+      @Override
+      public boolean shouldStopProcess() {
+        return true;
+      }
+    });
+
+    assertTrue(System.currentTimeMillis() - start > 700);
+    assertEquals(PROCESS_TERMINATED_CODE, execute);
+  }
+
+  @Test
   public void should_fail_if_script_not_found() {
     thrown.expect(CommandException.class);
     Command command = Command.builder().setExecutable("notfound").setDirectory(workDir).build();
-    CommandExecutor.create().execute(command, stdout, stderr, 1000L);
+    CommandExecutor.create().execute(command, stdout, stderr, 1000L, ACTIVITY_CONTROLLER);
   }
 
   private static String getScript(String name) throws IOException {


### PR DESCRIPTION
Hi Guys,

To keet the story short :) :
We are using sonar runner embedded in our IntelliJ sonar plugin. We almost finished the work for that, but we found out that there is a new API build during that time. 
I  did an evaluation for the new API for the sonar runner and we would like to use it. (https://github.com/gshakhn/sonar-intellij-plugin/pull/38).

I noticed that we ForketSonarRunner cannot be stopped once is started. In our IntelliJ--run-local-analysis-sonar integration we offer the possibility to stop the runner once it was started. 

Please my contribution which adds the possibility to stop the sonar runner. I tried to not bring to much impact on the "current interface". Woud be really great if we would have this feature since then we could finalize the run-local-analysis with the newest API. 

Please review/feedback if this fix can be pushed to sonar runner. I would be glad to tweak if necessary.

Kind regards,
Alpar
