### PR TITLE
BUILD-4839 Update release workflow to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@d42e8be3a9772d0447a7d2f3d2be31312b218383  # tag=5.0.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v5
     with:
       publishToBinaries: true
       mavenCentralSync: true


### PR DESCRIPTION
Release Action version 5.5.0 has been published. Update the release workflow to use the v5 branch for future updates. More details are at https://github.com/SonarSource/gh-action_release/releases.