### PR TITLE
BUILD-5727 Update Cirrus CI image used to use JDK21 LTS instead of JDK18 EOL

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ env:
 # RE-USABLE CONFIGS
 #
 container_definition: &CONTAINER_DEFINITION
-  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j18-latest
+  image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j21-latest
   cluster_name: ${CIRRUS_CLUSTER_NAME}
   region: eu-central-1
   namespace: default

--- a/lib/src/test/java/org/sonarsource/scanner/lib/internal/cache/FileHashesTest.java
+++ b/lib/src/test/java/org/sonarsource/scanner/lib/internal/cache/FileHashesTest.java
@@ -33,8 +33,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
     <gitRepositoryName>sonar-scanner-java-library</gitRepositoryName>
     <okhttp.version>4.12.0</okhttp.version>
     <mockito.version>3.12.4</mockito.version>
+    <byte-buddy.version>1.14.18</byte-buddy.version>
   </properties>
 
   <dependencyManagement>
@@ -128,6 +129,18 @@
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.16.1</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${byte-buddy.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${byte-buddy.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,6 @@
     <gitRepositoryName>sonar-scanner-java-library</gitRepositoryName>
     <okhttp.version>4.12.0</okhttp.version>
     <mockito.version>5.12.0</mockito.version>
-    <byte-buddy.version>1.14.18</byte-buddy.version>
   </properties>
 
   <dependencyManagement>
@@ -123,25 +122,13 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.24.2</version>
+        <version>3.26.3</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>1.16.1</version>
       </dependency>
-<!--      <dependency>-->
-<!--        <groupId>net.bytebuddy</groupId>-->
-<!--        <artifactId>byte-buddy</artifactId>-->
-<!--        <version>${byte-buddy.version}</version>-->
-<!--        <scope>test</scope>-->
-<!--      </dependency>-->
-<!--      <dependency>-->
-<!--        <groupId>net.bytebuddy</groupId>-->
-<!--        <artifactId>byte-buddy-agent</artifactId>-->
-<!--        <version>${byte-buddy.version}</version>-->
-<!--        <scope>test</scope>-->
-<!--      </dependency>-->
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-scanner-java-library</gitRepositoryName>
     <okhttp.version>4.12.0</okhttp.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>5.12.0</mockito.version>
     <byte-buddy.version>1.14.18</byte-buddy.version>
   </properties>
 
@@ -130,18 +130,18 @@
         <artifactId>commons-codec</artifactId>
         <version>1.16.1</version>
       </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy</artifactId>
-        <version>${byte-buddy.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>net.bytebuddy</groupId>
-        <artifactId>byte-buddy-agent</artifactId>
-        <version>${byte-buddy.version}</version>
-        <scope>test</scope>
-      </dependency>
+<!--      <dependency>-->
+<!--        <groupId>net.bytebuddy</groupId>-->
+<!--        <artifactId>byte-buddy</artifactId>-->
+<!--        <version>${byte-buddy.version}</version>-->
+<!--        <scope>test</scope>-->
+<!--      </dependency>-->
+<!--      <dependency>-->
+<!--        <groupId>net.bytebuddy</groupId>-->
+<!--        <artifactId>byte-buddy-agent</artifactId>-->
+<!--        <version>${byte-buddy.version}</version>-->
+<!--        <scope>test</scope>-->
+<!--      </dependency>-->
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Changes

- [x] Update Cirrus CI image used to use JDK21 LTS instead of JDK18 EOL)
      (JDK18 will no longer be produced by ci-docker-images project as it is EOL)
- [x]  Update buddy-bytes
        That way it works with JDKs <= 23