### PR TITLE
SCANJLIB-236 Map JVM cacerts to the new ssl properties

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ build_task:
   eks_container:
     <<: *CONTAINER_DEFINITION
     cpu: 2
-    memory: 1G
+    memory: 2G
   env:
     SONAR_TOKEN: VAULT[development/kv/data/next data.token]
     SONAR_HOST_URL: https://next.sonarqube.com/sonarqube
@@ -87,7 +87,7 @@ qa_task:
     <<: *CONTAINER_DEFINITION
     image: ${CIRRUS_AWS_ACCOUNT}.dkr.ecr.eu-central-1.amazonaws.com/base:j17-latest
     cpu: 2
-    memory: 3G
+    memory: 4G
   env:
     matrix:
       - SQ_VERSION: LATEST_RELEASE

--- a/its/it-tests/src/test/java/com/sonar/scanner/lib/it/ProxyTest.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/lib/it/ProxyTest.java
@@ -202,23 +202,20 @@ public class ProxyTest {
     SimpleScanner scanner = new SimpleScanner();
 
     Map<String, String> params = new HashMap<>();
-    // By default no request to localhost will use proxy
-    params.put("http.nonProxyHosts", "");
-    params.put("http.proxyHost", "localhost");
-    params.put("http.proxyPort", "" + httpProxyPort);
+    params.put("sonar.scanner.proxyHost", "localhost");
+    params.put("sonar.scanner.proxyPort", "" + httpProxyPort);
 
     BuildResult buildResult = scanner.executeSimpleProject(project("js-sample"), ORCHESTRATOR.getServer().getUrl(), params, Map.of());
     assertThat(buildResult.getLastStatus()).isEqualTo(1);
     assertThat(buildResult.getLogs()).contains("Error status returned by url", ": 407");
     assertThat(seenByProxy).isEmpty();
 
-    params.put("http.proxyUser", PROXY_USER);
-    params.put("http.proxyPassword", PROXY_PASSWORD);
+    params.put("sonar.scanner.proxyUser", PROXY_USER);
+    params.put("sonar.scanner.proxyPassword", PROXY_PASSWORD);
     buildResult = scanner.executeSimpleProject(project("js-sample"), ORCHESTRATOR.getServer().getUrl(), params, Map.of());
     assertThat(seenByProxy).isNotEmpty();
-    if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(6, 1)) {
-      assertThat(buildResult.getLastStatus()).isZero();
-    }
+    System.out.println(buildResult.getLogs());
+    assertThat(buildResult.getLastStatus()).isZero();
   }
 
 }

--- a/its/it-tests/src/test/java/com/sonar/scanner/lib/it/ScannerJavaLibraryTestSuite.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/lib/it/ScannerJavaLibraryTestSuite.java
@@ -39,8 +39,7 @@ public class ScannerJavaLibraryTestSuite {
   public static final OrchestratorRule ORCHESTRATOR = OrchestratorRule.builderEnv()
     .setSonarVersion(System.getProperty(SONAR_RUNTIME_VERSION, "DEV"))
     .useDefaultAdminCredentialsForBuilds(true)
-    // We need to use a plugin compatible with both SonarQube DEV & SonarQube version defined in .cirrus.yml (currently SQ 7.9)
-    .addPlugin(MavenLocation.of("org.sonarsource.javascript", "sonar-javascript-plugin", "7.4.4.15624"))
+    .addBundledPluginToKeep("sonar-javascript")
     .build();
 
   public static void resetData(OrchestratorRule orchestrator) {

--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/http/OkHttpClientFactory.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/http/OkHttpClientFactory.java
@@ -113,11 +113,11 @@ public class OkHttpClientFactory {
       sslFactoryBuilder.withSystemPropertyDerivedIdentityMaterial();
     }
     var keyStoreConfig = sslConfig.getKeyStore();
-    if (keyStoreConfig != null && Files.exists(keyStoreConfig.getPath())) {
+    if (keyStoreConfig != null) {
       sslFactoryBuilder.withIdentityMaterial(keyStoreConfig.getPath(), keyStoreConfig.getKeyStorePassword().toCharArray(), keyStoreConfig.getKeyStoreType());
     }
     var trustStoreConfig = sslConfig.getTrustStore();
-    if (trustStoreConfig != null && Files.exists(trustStoreConfig.getPath())) {
+    if (trustStoreConfig != null) {
       KeyStore trustStore = loadKeyStoreWithBouncyCastle(
         trustStoreConfig.getPath(),
         trustStoreConfig.getKeyStorePassword().toCharArray(),

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
 
   <properties>
     <maven.compiler.release>11</maven.compiler.release>
-    <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
     <!-- used for deployment to SonarSource Artifactory -->
     <gitRepositoryName>sonar-scanner-java-library</gitRepositoryName>


### PR DESCRIPTION
I did some manual testing, but I don't see how I can create an IT, because I would need to insert a certificate in the JVM truststore.

Maybe doable on the Scanner CLI side, I will try later.