### PR TITLE
SCANJLIB-169 Omit the stack trace of connection errors with SonarQube

### DIFF
--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/IsolatedLauncherFactory.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/IsolatedLauncherFactory.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -78,6 +79,8 @@ public class IsolatedLauncherFactory {
       tempCleaning.clean();
 
       return new IsolatedLauncherAndClassloader(objProxy, cl, jarFiles.stream().allMatch(CachedFile::isCacheHit));
+    } catch (IllegalStateException e) {
+      throw new ScannerException("Unable to execute SonarScanner analysis: " + Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse(e.getMessage()));
     } catch (Exception e) {
       // Catch all other exceptions, which relates to reflection
       throw new ScannerException("Unable to execute SonarScanner analysis", e);

--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/ScannerException.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/ScannerException.java
@@ -21,6 +21,10 @@ package org.sonarsource.scanner.lib.internal;
 
 public class ScannerException extends RuntimeException {
 
+  public ScannerException(String message) {
+    super(message);
+  }
+
   public ScannerException(String message, Throwable cause) {
     super(message, cause);
   }


### PR DESCRIPTION
[SCANJLIB-169](https://sonarsource.atlassian.net/browse/SCANJLIB-169)



[SCANJLIB-169]: https://sonarsource.atlassian.net/browse/SCANJLIB-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ