### PR TITLE
SCANJLIB-244 Log server type info on bootstrap

### DIFF
--- a/lib/src/main/java/org/sonarsource/scanner/lib/ScannerEngineFacade.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/ScannerEngineFacade.java
@@ -48,4 +48,11 @@ public interface ScannerEngineFacade extends AutoCloseable {
    * @return true if the analysis succeeded, false otherwise.
    */
   boolean analyze(Map<String, String> analysisProps);
+
+  /**
+   * Get the label of the server that the scanner is connected to. Distinguishes SonarQube Cloud, SonarQube Server and SonarQube Community Build.
+   *
+   * @return whether scanner is connected to SonarQube Cloud, Server or Community Build.
+   */
+  String getServerLabel();
 }

--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/facade/AbstractScannerEngineFacade.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/facade/AbstractScannerEngineFacade.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.sonarsource.scanner.lib.ScannerEngineFacade;
 import org.sonarsource.scanner.lib.internal.facade.forked.JreCacheHit;
+import org.sonarsource.scanner.lib.internal.util.VersionUtils;
 
 public abstract class AbstractScannerEngineFacade implements ScannerEngineFacade {
 
@@ -81,5 +82,18 @@ public abstract class AbstractScannerEngineFacade implements ScannerEngineFacade
   @Override
   public Map<String, String> getBootstrapProperties() {
     return bootstrapProperties;
+  }
+
+  @Override
+  public String getServerLabel() {
+    if (isSonarCloud()) {
+      return "SonarQube Cloud";
+    }
+
+    String version = getServerVersion();
+    if (VersionUtils.compareMajor(version, 10) <= 0 || VersionUtils.compareMajor(version, 2025) >= 0) {
+      return "SonarQube Server";
+    }
+    return "SonarQube Community Build";
   }
 }

--- a/lib/src/test/java/org/sonarsource/scanner/lib/internal/facade/simulation/SimulationScannerEngineFacadeTest.java
+++ b/lib/src/test/java/org/sonarsource/scanner/lib/internal/facade/simulation/SimulationScannerEngineFacadeTest.java
@@ -25,9 +25,13 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.sonarsource.scanner.lib.internal.InternalProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,6 +75,26 @@ class SimulationScannerEngineFacadeTest {
     assertThatThrownBy(() -> underTest.analyze(props))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Fail to export scanner properties");
+  }
+
+  @Test
+  void test_get_type_cloud() {
+    assertThat(underTest.getServerLabel()).isEqualTo("SonarQube Cloud");
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideServerVersionAndTypeArgumentPairs")
+  void test_get_types_server_and_community_build(String serverVersion, String serverType) {
+    assertThat(new SimulationScannerEngineFacade(new HashMap<>(), false, serverVersion).getServerLabel()).isEqualTo(serverType);
+  }
+
+  private static Stream<Arguments> provideServerVersionAndTypeArgumentPairs() {
+    return Stream.of(
+      Arguments.of("10.6", "SonarQube Server"),
+      Arguments.of("2025.1.0.1234", "SonarQube Server"),
+      Arguments.of("24.12", "SonarQube Community Build"),
+      Arguments.of("25.1.0.1234", "SonarQube Community Build")
+    );
   }
 
   private Map<String, String> createProperties() {

--- a/lib/src/test/java/org/sonarsource/scanner/lib/internal/util/VersionUtilsTest.java
+++ b/lib/src/test/java/org/sonarsource/scanner/lib/internal/util/VersionUtilsTest.java
@@ -42,4 +42,32 @@ class VersionUtilsTest {
     assertThat(VersionUtils.isAtLeastIgnoringQualifier("10.6-SNAPSHOT", "10.5")).isTrue();
     assertThat(VersionUtils.isAtLeastIgnoringQualifier("10.5.0.1234", "10.5")).isTrue();
   }
+
+  @Test
+  void compareMajor_shouldCompareMajorCorrectly() {
+    assertThat(VersionUtils.compareMajor(null, 10)).isNegative();
+    assertThat(VersionUtils.compareMajor("fhk10.5.0.1234", 10)).isNegative();
+
+    assertThat(VersionUtils.compareMajor("10.5.0.1234", 10)).isZero();
+    assertThat(VersionUtils.compareMajor("11.5.0.1234", 10)).isPositive();
+    assertThat(VersionUtils.compareMajor("8.5.0.1234", 10)).isNegative();
+
+    assertThat(VersionUtils.compareMajor("10.0-SNAPSHOT", 10)).isZero();
+    assertThat(VersionUtils.compareMajor(" 10.5.0.1234", 10)).isZero();
+    assertThat(VersionUtils.compareMajor("", 10)).isNegative();
+
+    assertThat(VersionUtils.compareMajor("2025.1.0.1234", 10)).isPositive();
+    assertThat(VersionUtils.compareMajor("2025.1-SNAPSHOT", 10)).isPositive();
+    assertThat(VersionUtils.compareMajor("klf2025.1-SNAPSHOT", 10)).isNegative();
+    assertThat(VersionUtils.compareMajor(" 2025.1-SNAPSHOT", 10)).isPositive();
+
+    assertThat(VersionUtils.compareMajor("25.1.0.1234", 10)).isPositive();
+    assertThat(VersionUtils.compareMajor("25.1-SNAPSHOT", 10)).isPositive();
+    assertThat(VersionUtils.compareMajor("fko25.1-SNAPSHOT", 10)).isNegative();
+    assertThat(VersionUtils.compareMajor(" 25.1-SNAPSHOT", 10)).isPositive();
+
+    assertThat(VersionUtils.compareMajor("25.1.0.1234", 26)).isNegative();
+    assertThat(VersionUtils.compareMajor("25.1-SNAPSHOT", 26)).isNegative();
+    assertThat(VersionUtils.compareMajor(" 25.1.0.1234", 26)).isNegative();
+  }
 }


### PR DESCRIPTION
[SCANJLIB-244](https://sonarsource.atlassian.net/browse/SCANJLIB-244)

**PR Scope**
- Log server type on bootstrap, distinguishing between SonarQube Cloud/Server/Community Build.

**TODOs:**
- After the changes are merged, the logging should be removed from sonar-scanner-cli and (potentially) sonar-scanner-maven and sonar-scanner-gradle; the version of the java library dependency should be updated accordingly
- Decide on whether the server edition type should be added to the log and whether that will belong to the scope of this task or another

**How to test?**
Run the scanner with the local version of sonar-scanner-java-library (3.2-SNAPSHOT)

1. When executing analysis using SonarQube Server:
- ‘Communicating with SonarQube Server {version}’ INFO log message should be displayed. Example: ‘Communicating with SonarQube Server 2025.1-SNAPSHOT’

2. When executing analysis using SonarQube Community Build:
- ‘Communicating with SonarQube Community Build {version}’ INFO log message should be displayed. Example: ’Communicating with SonarQube Community Build 25.1-SNAPSHOT’

3. When executing analysis using SonarQube Cloud:
- ’Communicating with SonarQube Cloud’ INFO log message should be displayed.


[SCANJLIB-244]: https://sonarsource.atlassian.net/browse/SCANJLIB-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Tasks
* [x] Investigate if some logs should be removed from the Sonar Scanner from Maven and Gradle
* [x] Create the ticket to remove the log line from sonar-scanner-cli
* [x] If relevant, create the tickets for the Maven and Gradle scanners