### PR TITLE
SCANJLIB-230 Add warning when sonar.login (and sonar.token simultaneo…

### DIFF
--- a/lib/src/main/java/org/sonarsource/scanner/lib/EnvironmentConfig.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/EnvironmentConfig.java
@@ -40,7 +40,7 @@ public class EnvironmentConfig {
   private static final String GENERIC_ENV_PREFIX = "SONAR_SCANNER_";
   private static final String SONAR_HOST_URL_ENV_VAR = "SONAR_HOST_URL";
   private static final String SONAR_USER_HOME_ENV_VAR = "SONAR_USER_HOME";
-  static final String TOKEN_ENV_VARIABLE = "SONAR_TOKEN";
+  public static final String TOKEN_ENV_VARIABLE = "SONAR_TOKEN";
 
   private EnvironmentConfig() {
     // only static methods

--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/http/HttpConfig.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/http/HttpConfig.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -39,6 +40,8 @@ import org.sonarsource.scanner.lib.internal.http.ssl.SslConfig;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.sonarsource.scanner.lib.EnvironmentConfig.TOKEN_ENV_VARIABLE;
+import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_LOGIN;
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_CONNECT_TIMEOUT;
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_KEYSTORE_PASSWORD;
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_KEYSTORE_PATH;
@@ -51,6 +54,7 @@ import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_SKIP_S
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_SOCKET_TIMEOUT;
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_TRUSTSTORE_PASSWORD;
 import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_SCANNER_TRUSTSTORE_PATH;
+import static org.sonarsource.scanner.lib.ScannerProperties.SONAR_TOKEN;
 
 public class HttpConfig {
 
@@ -87,6 +91,10 @@ public class HttpConfig {
     this.restApiBaseUrl = StringUtils.removeEnd(bootstrapProperties.get(ScannerProperties.API_BASE_URL), "/");
     this.token = bootstrapProperties.get(ScannerProperties.SONAR_TOKEN);
     this.login = bootstrapProperties.get(ScannerProperties.SONAR_LOGIN);
+    if (Objects.nonNull(this.login) && Objects.nonNull(this.token)) {
+      LOG.warn("Both '{}' and '{}' (or the '{}' env variable) are set, but only the latter will be used.", SONAR_LOGIN, SONAR_TOKEN, TOKEN_ENV_VARIABLE);
+    }
+
     this.password = bootstrapProperties.get(ScannerProperties.SONAR_PASSWORD);
     this.userAgent = format("%s/%s", bootstrapProperties.get(InternalProperties.SCANNER_APP), bootstrapProperties.get(InternalProperties.SCANNER_APP_VERSION));
     this.socketTimeout = loadDuration(bootstrapProperties, SONAR_SCANNER_SOCKET_TIMEOUT, READ_TIMEOUT_SEC_PROPERTY, DEFAULT_READ_TIMEOUT_SEC);


### PR DESCRIPTION
[SCANJLIB-230](https://sonarsource.atlassian.net/browse/SCANJLIB-230)

…usly) is used

I have determined the SonarQube Server version when the sonar.token property was introduced from the fix version of the [following task.](https://sonarsource.atlassian.net/browse/SONAR-18591)

**How to test?**
Run the scanner with both the sonar.token and sonar.login properties set, the following two warnings should be displayed in the logs:
`11:28:24.316 WARN  Both 'sonar.login' and 'sonar.token' (or the 'SONAR_TOKEN' env variable) are set, but only the latter will be used.`
`11:28:24.680 WARN  Use of 'sonar.login' property has been deprecated in favor of 'sonar.token' (or the env variable alternative 'SONAR_TOKEN'). Please use the latter when passing a token.`

**However, to discuss:**
As for this point of the task: _ensure that token effectively has priority over basic auth (also check in the scanner engine of SQS and SQC)_
- Not the case for the scanner engine (both in Server and Cloud) (due to for example line 90 in `ScannerWsClientProvider.java` in sonarqube - if the login property is present, it is not overriden).

[SCANJLIB-230]: https://sonarsource.atlassian.net/browse/SCANJLIB-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ