### PR TITLE
SCANJLIB-250 Preserve stderr/stdout when the command fails early

### DIFF
--- a/lib/src/main/java/org/sonarsource/scanner/lib/internal/facade/forked/JavaRunner.java
+++ b/lib/src/main/java/org/sonarsource/scanner/lib/internal/facade/forked/JavaRunner.java
@@ -56,15 +56,15 @@ public class JavaRunner {
         LOG.debug("Executing: {}", String.join(" ", command));
       }
       Process process = new ProcessBuilder(command).start();
-      if (input != null) {
-        try (var stdin = process.getOutputStream(); var osw = new OutputStreamWriter(stdin, StandardCharsets.UTF_8)) {
-          osw.write(input);
-        }
-      }
       var stdoutConsummer = new StreamGobbler(process.getInputStream(), stdOutConsummer);
       var stdErrConsummer = new StreamGobbler(process.getErrorStream(), stderr -> LOG.error("[stderr] {}", stderr));
       stdErrConsummer.start();
       stdoutConsummer.start();
+      if (input != null && process.isAlive()) {
+        try (var stdin = process.getOutputStream(); var osw = new OutputStreamWriter(stdin, StandardCharsets.UTF_8)) {
+          osw.write(input);
+        }
+      }
       var exitCode = process.waitFor();
       stdoutConsummer.join();
       stdErrConsummer.join();

--- a/lib/src/test/java/org/sonarsource/scanner/lib/ScannerEngineBootstrapperTest.java
+++ b/lib/src/test/java/org/sonarsource/scanner/lib/ScannerEngineBootstrapperTest.java
@@ -403,15 +403,15 @@ class ScannerEngineBootstrapperTest {
 
     when(httpConfig.getSslConfig())
       .thenReturn(new SslConfig(
-        new CertificateStore(Paths.get("some/keystore.p12"), "keystorePass"),
-        new CertificateStore(Paths.get("some/truststore.p12"), "truststorePass")));
+        new CertificateStore(Paths.get("some", "keystore.p12"), "keystorePass"),
+        new CertificateStore(Paths.get("some", "truststore.p12"), "truststorePass")));
 
     underTest.adaptDeprecatedPropertiesForInProcessBootstrapping(Map.of(), httpConfig);
 
     assertThat(System.getProperties()).contains(
-      entry("javax.net.ssl.keyStore", "some/keystore.p12"),
+      entry("javax.net.ssl.keyStore", Paths.get("some", "keystore.p12").toString()),
       entry("javax.net.ssl.keyStorePassword", "keystorePass"),
-      entry("javax.net.ssl.trustStore", "some/truststore.p12"),
+      entry("javax.net.ssl.trustStore", Paths.get("some", "truststore.p12").toString()),
       entry("javax.net.ssl.trustStorePassword", "truststorePass"));
   }
 

--- a/lib/src/test/java/org/sonarsource/scanner/lib/internal/facade/forked/JavaRunnerTest.java
+++ b/lib/src/test/java/org/sonarsource/scanner/lib/internal/facade/forked/JavaRunnerTest.java
@@ -60,6 +60,15 @@ class JavaRunnerTest {
   }
 
   @Test
+  void execute_shouldLogProcessStdError_and_skip_writing_to_stdin_when_process_fails_early() {
+    JavaRunner runner = new JavaRunner(Paths.get("java"), JreCacheHit.DISABLED);
+    List<String> command = List.of("-xyz");
+    assertThat(runner.execute(command, "test", stdOut::add)).isFalse();
+
+    assertThat(logTester.logs(Level.ERROR)).anyMatch(s -> s.startsWith("[stderr] Unrecognized option: -xyz"));
+  }
+
+  @Test
   void execute_whenInvalidRunner_shouldFail() {
     JavaRunner runner = new JavaRunner(Paths.get("invalid-runner"), JreCacheHit.DISABLED);
     List<String> command = List.of("--version");


### PR DESCRIPTION
[SCANJLIB-250](https://sonarsource.atlassian.net/browse/SCANJLIB-250)



[SCANJLIB-250]: https://sonarsource.atlassian.net/browse/SCANJLIB-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ