### PR TITLE
SCANJLIB-269 Bump jetty from 9.4.55.v20240627 to 10.0.25

### DIFF
--- a/its/it-tests/pom.xml
+++ b/its/it-tests/pom.xml
@@ -11,7 +11,7 @@
   <description>Integration tests</description>
   
   <properties>
-    <jetty.version>9.4.55.v20240627</jetty.version>
+    <jetty.version>10.0.25</jetty.version>
     <logback.version>1.3.15</logback.version>
     <sonar.skip>true</sonar.skip>
     <skipTests>true</skipTests>

--- a/its/it-tests/src/test/java/com/sonar/scanner/lib/it/tools/ProxyAuthenticator.java
+++ b/its/it-tests/src/test/java/com/sonar/scanner/lib/it/tools/ProxyAuthenticator.java
@@ -39,6 +39,7 @@ package com.sonar.scanner.lib.it.tools;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -52,7 +53,6 @@ import org.eclipse.jetty.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Authentication.User;
 import org.eclipse.jetty.server.UserIdentity;
-import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.security.Constraint;
 
 /**
@@ -92,7 +92,7 @@ public class ProxyAuthenticator extends LoginAuthenticator {
           String method = credentials.substring(0, space);
           if ("basic".equalsIgnoreCase(method)) {
             credentials = credentials.substring(space + 1);
-            credentials = B64Code.decode(credentials, StandardCharsets.ISO_8859_1);
+            credentials = new String(Base64.getDecoder().decode(credentials), StandardCharsets.ISO_8859_1);
             int i = credentials.indexOf(':');
             if (i > 0) {
               String username = credentials.substring(0, i);


### PR DESCRIPTION
[SCANJLIB-269](https://sonarsource.atlassian.net/browse/SCANJLIB-269)

10.0.25 is the nearest version without known vulnerabilities. I tried to Bump to a more recent version (12.0.20), but it requires migrating to Jakarta first.



[SCANJLIB-269]: https://sonarsource.atlassian.net/browse/SCANJLIB-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ